### PR TITLE
Update player selection options to include '1' in various components

### DIFF
--- a/frontend/src/app/search/page.tsx
+++ b/frontend/src/app/search/page.tsx
@@ -182,7 +182,7 @@ export default function SearchPage() {
 
       // Players
       const playersParam = params.get('players') || params.get('numOfPlayers');
-      if (playersParam && ["2","3","4","any"].includes(playersParam)) {
+      if (playersParam && ["1","2","3","4","any"].includes(playersParam)) {
         setNumOfPlayers(playersParam);
       }
 

--- a/frontend/src/components/MobileSidebar.tsx
+++ b/frontend/src/components/MobileSidebar.tsx
@@ -431,8 +431,8 @@ export default function MobileSidebar({
                       <Users className="w-5 h-5 text-slate-600" />
                       <span className="text-sm font-semibold text-slate-800 tracking-wide uppercase">Players</span>
                     </div>
-                    <div className="grid grid-cols-4 gap-2">
-                      {["2", "3", "4", "any"].map((option) => (
+                    <div className="grid grid-cols-5 gap-2">
+                      {["1", "2", "3", "4", "any"].map((option) => (
                         <button
                           key={option}
                           onClick={() => setNumOfPlayers(option)}

--- a/frontend/src/components/Sidebar.tsx
+++ b/frontend/src/components/Sidebar.tsx
@@ -365,20 +365,28 @@ export default function Sidebar({
               <Users className="w-5 h-5 text-slate-600" />
               <span className="text-sm font-semibold text-slate-800 tracking-wide uppercase">Players</span>
             </div>
-            <div className="flex gap-2">
-              {["2", "3", "4", "any"].map((option) => (
-                <button
-                  key={option}
-                  onClick={() => setNumOfPlayers(option)}
-                  className={`flex-1 px-3 py-2 rounded-lg border text-sm transition-all duration-200 ${
-                    numOfPlayers === option
-                      ? 'bg-sidebar-primary text-white border-sidebar-primary shadow-md'
-                      : 'bg-white hover:bg-green-200 border-slate-200 text-slate-700 hover:border-sidebar-primary'
-                  }`}
-                >
-                  {option === "any" ? "Any" : option}
-                </button>
-              ))}
+            <div className="flex">
+              {["1", "2", "3", "4", "any"].map((option, idx, arr) => {
+                const isFirst = idx === 0;
+                const isLast = idx === arr.length - 1;
+                return (
+                  <button
+                    key={option}
+                    onClick={() => setNumOfPlayers(option)}
+                    className={`flex-1 px-3 py-2 border text-sm transition-all duration-200 ${
+                      isFirst ? 'rounded-l-lg' : isLast ? 'rounded-r-lg' : 'rounded-none'
+                    } ${
+                      idx > 0 ? '-ml-px' : ''
+                    } ${
+                      numOfPlayers === option
+                        ? 'bg-sidebar-primary text-white border-sidebar-primary shadow-md'
+                        : 'bg-white hover:bg-green-200 border-slate-200 text-slate-700 hover:border-sidebar-primary'
+                    }`}
+                  >
+                    {option === "any" ? "Any" : option}
+                  </button>
+                );
+              })}
             </div>
           </div>
 
@@ -400,7 +408,7 @@ export default function Sidebar({
             </div>
             <Listbox value={holes} onChange={setHoles}>
               <div className="relative">
-                <Listbox.Button className="w-full px-4 py-2 text-left bg-white border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-sidebar-primary hover:border-sidebar-primary transition-colors font-medium text-slate-700">
+                <Listbox.Button className="w-full px-4 py-2 text-left bg-white border border-slate-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-sidebar-primary hover:border-sidebar-primary transition-colors font-medium text-sm text-slate-700">
                   <span>{holes === "any" ? "Any" : holes}</span>
                   <ChevronDown className="absolute right-3 top-1/2 -translate-y-1/2 w-5 h-5 text-slate-400" />
                 </Listbox.Button>

--- a/frontend/src/components/WatchlistFilters.tsx
+++ b/frontend/src/components/WatchlistFilters.tsx
@@ -348,7 +348,7 @@ export default function WatchlistFilters({
                   <span className="text-sm font-semibold text-slate-800 tracking-wide uppercase">Players</span>
                 </div>
                 <div className="flex gap-2">
-                  {["2", "3", "4", "any"].map((option) => (
+                  {["1", "2", "3", "4", "any"].map((option) => (
                     <button
                       key={option}
                       onClick={() => setNumOfPlayers(option)}


### PR DESCRIPTION
- Modified player selection logic in SearchPage, MobileSidebar, Sidebar, and WatchlistFilters to include '1' as a valid option.
- Adjusted UI elements to accommodate the new player count, enhancing user experience and flexibility in player selection.